### PR TITLE
- redis connection options are not passed down correctly.

### DIFF
--- a/redis-transport.js
+++ b/redis-transport.js
@@ -48,8 +48,8 @@ module.exports = function( options ) {
     var type           = args.type
     var listen_options = seneca.util.clean(_.extend({},options[type],args))
 
-    var redis_in  = redis.createClient(listen_options.port,listen_options.host)
-    var redis_out = redis.createClient(listen_options.port,listen_options.host)
+    var redis_in  = redis.createClient(listen_options.port,listen_options.host, listen_options)
+    var redis_out = redis.createClient(listen_options.port,listen_options.host, listen_options)
 
     handle_events(redis_in)
     handle_events(redis_out)


### PR DESCRIPTION
- to test, setup password in redis and then try to connect like below:
require('seneca')()
    .use('redis-transport', {redis: {auth_pass: 'somesecret'}})